### PR TITLE
refactor: update health check endpoint path to include /api prefix

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -206,7 +206,7 @@ def log_request_info():
 #     return response
 # -------------------------------------------------
 
-@application.route('/health', methods=['GET'])
+@application.route('/api/health', methods=['GET'])
 def health():
     """A simple health check endpoint to verify the API is running."""
     return jsonify(message="API is up and running!"), 200


### PR DESCRIPTION
- Changed the health check endpoint from `/health` to `/api/health` to align with the new API routing structure established in previous commits, ensuring consistency across the application.