### PR TITLE
refactor: update API endpoint paths and enhance logging

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -151,7 +151,7 @@ def verify_jwt():
 
     public_paths = [
         '/contact/create',
-        '/scraping/create',
+        '/api/scraping/create',
         '/scraping/update-password',
         '/scraping/login',
         '/webhooks/stripe/create'

--- a/api/scraping/routes.py
+++ b/api/scraping/routes.py
@@ -38,6 +38,12 @@ def validate_contact_value_unique(contact_value: str, exclude_id: int = None) ->
 # Create
 @blueprint.route("/create", methods=["POST"])
 def create():
+    current_app.logger.info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    current_app.logger.info("!!!      /SCRAPING/CREATE ENDPOINT HIT      !!!")
+    current_app.logger.info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    current_app.logger.info(f"Request Method: {request.method}")
+    current_app.logger.info(f"Request Path: {request.path}")
+    current_app.logger.info(f"Request URL: {request.url}")
     current_app.logger.info("=== INICIO DO ENDPOINT /create ===")
     
     try:

--- a/app/src/components/LockedPage.tsx
+++ b/app/src/components/LockedPage.tsx
@@ -194,7 +194,7 @@ export function LockedPage() {
         contact_type_id: contactTypeId
       };
       
-      const response = await api.post('/scraping/create', requestData);
+      const response = await api.post('/api/scraping/create', requestData);
 
       if (response.status === 201) {
         setFormData({

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -26,7 +26,7 @@ server {
 
     # Rule for API calls
     location /api/ {
-        proxy_pass http://api:5000/;
+        proxy_pass http://api:5000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
- Changed the endpoint path for scraping creation from `/scraping/create` to `/api/scraping/create` to maintain consistency with the new API routing structure.
- Added detailed logging for the `/create` endpoint in `routes.py` to improve monitoring and debugging capabilities, capturing request method, path, and URL.
- Updated the Nginx configuration to ensure proper proxy handling for the new API endpoint structure.