### PR TITLE
chore: update Nginx configuration to include Docker DNS resolver

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -20,6 +20,7 @@ server {
 server {
     listen 80;
     server_name locked.lureclo.com;
+    resolver 127.0.0.11 valid=30s; # Docker's internal DNS resolver
 
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log;


### PR DESCRIPTION
- Added a resolver directive to the Nginx configuration for the server block, specifying Docker's internal DNS resolver with a validity of 30 seconds. This change enhances DNS resolution for the server.