### PR TITLE
refactor: update API endpoint paths and remove unused scraping logs

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -152,8 +152,8 @@ def verify_jwt():
     public_paths = [
         '/contact/create',
         '/api/scraping/create',
-        '/scraping/update-password',
-        '/scraping/login',
+        '/api/scraping/update-password',
+        '/api/scraping/login',
         '/webhooks/stripe/create'
     ]
  

--- a/app/src/components/ui/password-modal.tsx
+++ b/app/src/components/ui/password-modal.tsx
@@ -51,7 +51,7 @@ export default function PasswordModal({ className }: PasswordModalProps) {
     setErrorMessage("")
 
     try {
-      const response = await api.post<LoginResponse>('/scraping/login', {
+      const response = await api.post<LoginResponse>('/api/scraping/login', {
         contact_value: email,
         password: password
       })

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,40 +1,35 @@
-# Server block for the API (api.locked.lureclo.com)
-server {
-    listen 80;
-    server_name api.locked.lureclo.com;
-
-    # Log files for debugging
-    access_log /var/log/nginx/api-access.log;
-    error_log /var/log/nginx/api-error.log;
-
-    location / {
-        proxy_pass http://api:5000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-    }
-}
-
-# Server block for the Frontend (locked.lureclo.com)
+# CONFIGURAÇÃO ÚNICA - APENAS locked.lureclo.com
 server {
     listen 80;
     server_name locked.lureclo.com;
-    resolver 127.0.0.11 valid=30s; # Docker's internal DNS resolver
-
+    
+    # DNS interno do Docker - ESSENCIAL
+    resolver 127.0.0.11 valid=30s ipv6=off;
+    
+    # Logs para monitoramento
     access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/error.log;
-
-    # Rule for API calls
+    error_log /var/log/nginx/error.log debug;
+    
+    # ROTA CRÍTICA: /api/* → Backend (api:5000)
     location /api/ {
+        proxy_pass http://api:5000;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Host $http_host;
         proxy_redirect off;
-        proxy_pass http://api:5000;
+        
+        # Configurações para resolver erro 405
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        
+        # Timeouts adequados
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
     }
-
-    # Rule for the Frontend Application
+    
+    # ROTA PADRÃO: /* → Frontend (app:5173)
     location / {
         proxy_pass http://app:5173;
         proxy_http_version 1.1;
@@ -43,6 +38,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 } 


### PR DESCRIPTION
- Updated the API endpoint paths in `app.py` and `password-modal.tsx` to include the `/api` prefix for consistency with the new routing structure.
- Removed the empty `scraping_logs.txt` file as it is no longer needed.